### PR TITLE
Fixed verify and resend-otp bug

### DIFF
--- a/src/controllers/authentication.js
+++ b/src/controllers/authentication.js
@@ -120,8 +120,8 @@ export default class Authentication {
    */
   static resendOTP = async (req, res) => {
     try {
-      const { phoneNumber } = req.userData;
-      const otpCode = await generateOTP();
+      const { phoneNumber, otp } = req.userData;
+      const otpCode = parseInt(otp, 10);
       if (process.env.NODE_ENV === 'production') {
         await sendOTP(phoneNumber, `${otpMessage} ${otpCode}`);
       }

--- a/src/routes/authRoutes.js
+++ b/src/routes/authRoutes.js
@@ -22,7 +22,7 @@ const {
 const authRoutes = express.Router();
 
 authRoutes.post('/signup', validateSignup, isUserRegistered, signUp);
-authRoutes.get('/verify', validateVerifyOTP, checkUserToken, checkOTP, verify);
+authRoutes.post('/verify', validateVerifyOTP, checkUserToken, checkOTP, verify);
 authRoutes.get('/verify/retry', checkUserToken, resendOTP);
 authRoutes.post('/login', validateLogin, checkLogin, login);
 authRoutes.get('/logout', checkUserToken, logout);

--- a/tests/authentication.test.js
+++ b/tests/authentication.test.js
@@ -149,7 +149,7 @@ describe('VERIFY SIGNUP', () => {
   it('Empty request should return 400', (done) => {
     chai
       .request(server)
-      .get(`${baseUrl}verify`)
+      .post(`${baseUrl}verify`)
       .set('Authorization', `Bearer ${userToken}`)
       .end((err, res) => {
         if (err) done(err);
@@ -163,7 +163,7 @@ describe('VERIFY SIGNUP', () => {
   it('Invalid OTP should return 400', (done) => {
     chai
       .request(server)
-      .get(`${baseUrl}verify`)
+      .post(`${baseUrl}verify`)
       .set('Authorization', `Bearer ${userToken}`)
       .send({
         otp: 'Ethan',
@@ -180,7 +180,7 @@ describe('VERIFY SIGNUP', () => {
   it('Unknown property should return 400', (done) => {
     chai
       .request(server)
-      .get(`${baseUrl}verify`)
+      .post(`${baseUrl}verify`)
       .set('Authorization', `Bearer ${userToken}`)
       .send({
         otp: '123456',
@@ -198,7 +198,7 @@ describe('VERIFY SIGNUP', () => {
   it('Wrong OTP should return 400', (done) => {
     chai
       .request(server)
-      .get(`${baseUrl}verify`)
+      .post(`${baseUrl}verify`)
       .set('Authorization', `Bearer ${userToken}`)
       .send({
         otp: '123456',
@@ -215,7 +215,7 @@ describe('VERIFY SIGNUP', () => {
   it('Valid OTP but absent token should return 400', (done) => {
     chai
       .request(server)
-      .get(`${baseUrl}verify`)
+      .post(`${baseUrl}verify`)
       .send({
         otp: userOTP,
       })
@@ -231,7 +231,7 @@ describe('VERIFY SIGNUP', () => {
   it('Valid OTP should return 200', (done) => {
     chai
       .request(server)
-      .get(`${baseUrl}verify`)
+      .post(`${baseUrl}verify`)
       .set('Authorization', `Bearer ${userToken}`)
       .send({
         otp: userOTP,


### PR DESCRIPTION
#### What does this PR do?

- Fixes a bug on `verify` endpoint
- Fixes a bug on `verify/retry` endpoint

#### Description of Task to be completed?

- [x] Refactor route method from `GET` to `POST` on `/api/auth/verify`
- [x] Refactor controller of `/api/auth/verify/retry` endpoint to send the OTP generated on signup instead of just generating a new one
