### PR TITLE
Added menu and payment endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,19 +17,23 @@ The API offers the following endpoints:
 | POST | /api/auth/login | Log in |
 | GET | /api/auth/logout | Log out |
 | POST | /api/orders | Create or place an order |
+| GET | /api/orders | User retrieve own list of orders |
 | GET | /api/orders/:id | User retrieve own single order |
+| GET | /api/menu | Retrieve menu categories and items |
+| POST | /api/payments | Create payment intent |
 | GET | /api/admin/orders/:id | Admin retrieve a single order |
 | GET | /api/admin/orders | Admin retrieve list of all the orders |
 | PATCH | /api/admin/orders/:id | Admin update status of a single order |
 
 <br/>
+
 ### Technologies used
 
 #### Databases
 1. PostgreSQL
 2. Redis
 
-#### Other libraries/frameworks
+#### Libraries/frameworks
 1. ExpressJS
 2. Sequelize ORM
 3. JSON Web Token
@@ -37,6 +41,7 @@ The API offers the following endpoints:
 5. Bcrypt
 6. Twilio
 7. Cors
+8. Stripe
 <br/><br/>
 
 ### CI/CD

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "sequelize": "^6.3.5",
     "sequelize-cli": "^6.2.0",
     "sequelize-test-helpers": "^1.3.2",
+    "stripe": "^8.138.0",
     "twilio": "^3.54.1"
   },
   "devDependencies": {
@@ -55,9 +56,11 @@
     "create-db": "npx sequelize-cli db:create",
     "drop-db": "npx sequelize-cli db:drop",
     "migrate": "npx sequelize-cli db:migrate",
-    "pretest": "yarn drop-db && yarn create-db && yarn migrate && yarn create-admin && yarn seed",
+    "pretest": "yarn lint && yarn drop-db && yarn create-db && yarn migrate && yarn create-admin && yarn seed",
     "heroku-postbuild": "yarn migrate && yarn create-admin",
     "create-admin": "babel-node ./src/database/scripts/adminScript.js",
-    "seed": "npx sequelize-cli db:seed:all"
+    "seed": "npx sequelize-cli db:seed:all",
+    "create-menu": "babel-node ./src/database/scripts/menuScript.js",
+    "lint": "yarn run eslint src/ && yarn run eslint tests/"
   }
 }

--- a/src/config/stripeConfig.js
+++ b/src/config/stripeConfig.js
@@ -1,0 +1,8 @@
+import dotenv from 'dotenv';
+import Stripe from 'stripe';
+
+dotenv.config();
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY);
+
+export default stripe;

--- a/src/controllers/menu.js
+++ b/src/controllers/menu.js
@@ -1,0 +1,30 @@
+import statusCodes from '../utils/statusCodes';
+import misc from '../helpers/misc';
+
+const {
+  serverError,
+  success,
+} = statusCodes;
+const {
+  successResponse,
+  errorResponse,
+} = misc;
+
+/**
+ * @description Class to handle the creation, retrieval and updating of orders
+ */
+export default class Menu {
+  /**
+   * @description method that returns the menu items
+   * @param {object} req
+   * @param {object} res
+   * @returns {object} Success | error response object
+   */
+  static getMenuItems = async (req, res) => {
+    try {
+      return successResponse(res, success, null, null, req.menuItems);
+    } catch (error) {
+      return errorResponse(res, serverError, error);
+    }
+  };
+}

--- a/src/database/models/contents.js
+++ b/src/database/models/contents.js
@@ -1,7 +1,7 @@
-'use strict';
 const {
-  Model
+  Model,
 } = require('sequelize');
+
 module.exports = (sequelize, DataTypes) => {
   class Contents extends Model {
     /**
@@ -14,12 +14,12 @@ module.exports = (sequelize, DataTypes) => {
         foreignKey: 'orderId',
       });
     }
-  };
+  }
   Contents.init({
     itemId: DataTypes.INTEGER,
     itemName: DataTypes.STRING,
     cost: DataTypes.DECIMAL,
-    quantity: DataTypes.INTEGER
+    quantity: DataTypes.INTEGER,
   }, {
     sequelize,
     modelName: 'Contents',

--- a/src/database/models/item.js
+++ b/src/database/models/item.js
@@ -1,7 +1,7 @@
-'use strict';
 const {
-  Model
+  Model,
 } = require('sequelize');
+
 module.exports = (sequelize, DataTypes) => {
   class Item extends Model {
     /**
@@ -14,13 +14,13 @@ module.exports = (sequelize, DataTypes) => {
         foreignKey: 'menuId',
       });
     }
-  };
+  }
   Item.init({
     name: DataTypes.STRING,
     description: DataTypes.STRING,
     cost: DataTypes.DECIMAL,
     size: DataTypes.STRING,
-    image: DataTypes.STRING
+    image: DataTypes.STRING,
   }, {
     sequelize,
     modelName: 'Item',

--- a/src/database/models/menu.js
+++ b/src/database/models/menu.js
@@ -1,7 +1,7 @@
-'use strict';
 const {
-  Model
+  Model,
 } = require('sequelize');
+
 module.exports = (sequelize, DataTypes) => {
   class Menu extends Model {
     /**
@@ -14,9 +14,9 @@ module.exports = (sequelize, DataTypes) => {
         foreignKey: 'menuId',
       });
     }
-  };
+  }
   Menu.init({
-    name: DataTypes.STRING
+    name: DataTypes.STRING,
   }, {
     sequelize,
     modelName: 'Menu',

--- a/src/database/models/order.js
+++ b/src/database/models/order.js
@@ -1,7 +1,7 @@
-'use strict';
 const {
-  Model
+  Model,
 } = require('sequelize');
+
 module.exports = (sequelize, DataTypes) => {
   class Order extends Model {
     /**
@@ -17,11 +17,11 @@ module.exports = (sequelize, DataTypes) => {
         foreignKey: 'userId',
       });
     }
-  };
+  }
   Order.init({
     total: DataTypes.DECIMAL,
     status: DataTypes.STRING,
-    paymentId: DataTypes.STRING
+    paymentId: DataTypes.STRING,
   }, {
     sequelize,
     modelName: 'Order',

--- a/src/database/models/user.js
+++ b/src/database/models/user.js
@@ -1,12 +1,11 @@
-'use strict';
-
 import roles from '../../utils/roles';
 
-const {CUSTOMER, STAFF, ADMIN} = roles;
+const { CUSTOMER, STAFF, ADMIN } = roles;
 
 const {
-  Model
+  Model,
 } = require('sequelize');
+
 module.exports = (sequelize, DataTypes) => {
   class User extends Model {
     /**
@@ -19,7 +18,7 @@ module.exports = (sequelize, DataTypes) => {
         foreignKey: 'userId',
       });
     }
-  };
+  }
   User.init({
     firstName: DataTypes.STRING,
     lastName: DataTypes.STRING,

--- a/src/database/scripts/menuScript.js
+++ b/src/database/scripts/menuScript.js
@@ -1,0 +1,98 @@
+import models from '../models';
+
+const { Menu, Item } = models;
+
+/**
+ * @description Clears the menu records
+ */
+const clearMenu = async () => {
+  await models.sequelize.query('DELETE FROM "Items";');
+  await models.sequelize.query('DELETE FROM "Menus";');
+};
+
+/**
+ * @description Creates the menu items
+ */
+const createItems = async (id, name) => {
+  switch (name) {
+    case 'Breakfast':
+      await Item.create({
+        menuId: id,
+        name: 'French Omelette De Fromage',
+        description: 'Our famous Omelette De Fromage with lots of Cheese.',
+        cost: 4.00,
+        size: 'Medium',
+        image: 'https://media.istockphoto.com/photos/omelette-picture-id155375267',
+      });
+      break;
+    case 'Lunch/Dinner':
+      await Item.create({
+        menuId: id,
+        name: 'Double Cheese Burger',
+        description: 'This is a very tasty cheese burger.',
+        cost: 6.50,
+        size: 'Large',
+        image: 'https://media.istockphoto.com/photos/delicious-fresh-cooked-burger-with-a-side-of-french-fries-picture-id177556385',
+      });
+      await Item.create({
+        menuId: id,
+        name: 'Chicken Pizza',
+        description: 'This is a very tasty Pizza.',
+        cost: 9.00,
+        size: 'Large',
+        image: 'https://media.istockphoto.com/photos/delicious-vegetarian-pizza-on-white-picture-id1192094401',
+      });
+      break;
+    case 'Drinks':
+      await Item.create({
+        menuId: id,
+        name: 'Diet Coke',
+        description: 'Diet Coke without added sugar.',
+        cost: 1.50,
+        size: 'Small',
+        image: 'https://media.istockphoto.com/photos/can-of-cocacola-on-ice-picture-id487787108',
+      });
+      await Item.create({
+        menuId: id,
+        name: 'Cappucinno',
+        description: 'The best Cappucinno in town.',
+        cost: 1.50,
+        size: 'Medium',
+        image: 'https://media.istockphoto.com/photos/paper-coffee-cup-and-lid-isolated-on-white-picture-id1165889671?s=612x612',
+      });
+      break;
+    default:
+      break;
+  }
+};
+
+/**
+ * @description Creates the menu categories
+ */
+const createCategories = async () => {
+  const categoriesData = [
+    { name: 'Breakfast' },
+    { name: 'Lunch/Dinner' },
+    { name: 'Drinks' },
+  ];
+  categoriesData.forEach(async (category) => {
+    const menu = await Menu.findOrCreate({
+      where: { name: category.name },
+      defaults: category,
+    });
+    const { id, name } = menu[0];
+    await createItems(id, name);
+  });
+};
+
+/**
+ * @description Clears and creates menu categories and their items
+ */
+const createMenu = async () => {
+  await clearMenu();
+  await createCategories();
+};
+
+createMenu();
+
+export default createMenu;

--- a/src/database/seeders/20210111131026-items.js
+++ b/src/database/seeders/20210111131026-items.js
@@ -47,7 +47,7 @@ module.exports = {
         description: 'The best Cappucinno in town.',
         cost: 1.50,
         size: 'Medium',
-        image: 'https://www.istockphoto.com/photo/3d-paper-coffee-cup-and-lid-isolated-on-white-gm1165889671-320956287',
+        image: 'https://media.istockphoto.com/photos/paper-coffee-cup-and-lid-isolated-on-white-picture-id1165889671?s=612x612',
         createdAt: new Date(),
         updatedAt: new Date(),
       },

--- a/src/middlewares/menu.js
+++ b/src/middlewares/menu.js
@@ -1,0 +1,33 @@
+import _ from 'lodash';
+import helpers from '../helpers/misc';
+import models from '../database/models';
+import services from '../services/services';
+import statusCodes from '../utils/statusCodes';
+import messages from '../utils/messages';
+
+const { errorResponse } = helpers;
+const { Menu, Item } = models;
+const { findMenuItems } = services;
+const { notFound, serverError } = statusCodes;
+const { menuNotFound } = messages;
+
+/**
+ * @description Retrieves the menu or returns an error response
+ * @param {object} req Request object
+ * @param {object} res Response object
+ * @param {function} next Callback function
+ */
+const findMenu = async (req, res, next) => {
+  try {
+    const menu = await findMenuItems(Menu, Item);
+    if (_.isEmpty(menu)) {
+      return errorResponse(res, notFound, menuNotFound);
+    }
+    req.menuItems = menu;
+    return next();
+  } catch (error) {
+    return errorResponse(res, serverError, error);
+  }
+};
+
+export default { findMenu };

--- a/src/middlewares/orders.js
+++ b/src/middlewares/orders.js
@@ -12,7 +12,11 @@ const {
   errorResponse,
 } = helpers;
 const { Order, Contents, User } = models;
-const { findOrderByConditionAll, findAllOrders } = services;
+const {
+  findOrderByConditionAll,
+  findAllOrders,
+  findAllUserOrders,
+} = services;
 const { notFound, serverError, conflict } = statusCodes;
 const { orderNotFound, ordersListNotFound, orderUpdateConflict } = messages;
 
@@ -89,7 +93,14 @@ const findUserOrderById = async (req, res, next) => {
  */
 const findOrdersList = async (req, res, next) => {
   try {
-    const orders = await findAllOrders(Order, Contents, User);
+    let orders;
+    const userId = req.userData.id;
+    const condition = { userId };
+    if (req.userData.role === 'customer') {
+      orders = await findAllUserOrders(Order, Contents, condition);
+    } else {
+      orders = await findAllOrders(Order, Contents, User);
+    }
     if (_.isEmpty(orders)) {
       return errorResponse(res, notFound, ordersListNotFound);
     }

--- a/src/middlewares/payments.js
+++ b/src/middlewares/payments.js
@@ -1,0 +1,54 @@
+import payments from '../validations/payments';
+import helpers from '../helpers/misc';
+import statusCodes from '../utils/statusCodes';
+import stripeConfig from '../config/stripeConfig';
+
+const {
+  returnErrorMessages,
+  errorResponse,
+  successResponse,
+} = helpers;
+const {
+  success,
+  serverError,
+} = statusCodes;
+const { initiatePayment } = payments;
+
+/**
+ * @description Wrapper function that exposes initiatePayment validation errors
+ * @param {object} req Request object
+ * @param {object} res Response object
+ * @param {function} next Callback function
+ */
+const validateInitiatePayment = async (req, res, next) => {
+  const { error } = initiatePayment(req.body);
+  returnErrorMessages(error, res, next);
+};
+
+/**
+ * @description Generates a payment intent to be confirmed on frontend
+ * @param {object} req Request object
+ * @param {object} res Response object
+ * @returns error message or JSON object containing publishableKey and clientSecret properties
+ */
+const generatePaymentIntent = async (req, res) => {
+  try {
+    const { amount } = req.body;
+    const paymentIntent = await stripeConfig.paymentIntents.create({
+      amount,
+      currency: 'usd',
+    });
+    const data = {
+      publishableKey: process.env.STRIPE_PUBLISHABLE_KEY,
+      clientSecret: paymentIntent.client_secret,
+    };
+    return successResponse(res, success, null, null, data);
+  } catch (error) {
+    return errorResponse(res, serverError, error.message);
+  }
+};
+
+export default {
+  validateInitiatePayment,
+  generatePaymentIntent,
+};

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -2,11 +2,15 @@ import express from 'express';
 import authRoutes from './authRoutes';
 import ordersRoutes from './ordersRoutes';
 import adminRoutes from './adminRoutes';
+import menuRoutes from './menuRoutes';
+import paymentsRoutes from './paymentsRoutes';
 
 const routes = express.Router();
 
 routes.use('/api/auth', authRoutes);
 routes.use('/api/orders', ordersRoutes);
 routes.use('/api/admin', adminRoutes);
+routes.use('/api/menu', menuRoutes);
+routes.use('/api/payments', paymentsRoutes);
 
 export default routes;

--- a/src/routes/menuRoutes.js
+++ b/src/routes/menuRoutes.js
@@ -1,0 +1,14 @@
+import express from 'express';
+import menuController from '../controllers/menu';
+import authMiddleware from '../middlewares/authentication';
+import menuMiddleware from '../middlewares/menu';
+
+const { getMenuItems } = menuController;
+const { checkUserToken } = authMiddleware;
+const { findMenu } = menuMiddleware;
+
+const menuRoutes = express.Router();
+
+menuRoutes.get('/', checkUserToken, findMenu, getMenuItems);
+
+export default menuRoutes;

--- a/src/routes/ordersRoutes.js
+++ b/src/routes/ordersRoutes.js
@@ -3,17 +3,19 @@ import ordersController from '../controllers/orders';
 import authMiddleware from '../middlewares/authentication';
 import ordersMiddleware from '../middlewares/orders';
 
-const { placeOrder, getSpecificOrder } = ordersController;
+const { placeOrder, getSpecificOrder, getOrdersList } = ordersController;
 const { checkUserToken } = authMiddleware;
 const {
   validatePlaceOrder,
   validateGetOrder,
   findUserOrderById,
+  findOrdersList,
 } = ordersMiddleware;
 
 const ordersRoutes = express.Router();
 
 ordersRoutes.post('/', validatePlaceOrder, checkUserToken, placeOrder);
-ordersRoutes.get('/:id', validateGetOrder, checkUserToken, findUserOrderById, getSpecificOrder );
+ordersRoutes.get('/:id', validateGetOrder, checkUserToken, findUserOrderById, getSpecificOrder);
+ordersRoutes.get('/', checkUserToken, findOrdersList, getOrdersList);
 
 export default ordersRoutes;

--- a/src/routes/paymentsRoutes.js
+++ b/src/routes/paymentsRoutes.js
@@ -1,0 +1,12 @@
+import express from 'express';
+import authMiddleware from '../middlewares/authentication';
+import paymentsMiddleware from '../middlewares/payments';
+
+const { checkUserToken } = authMiddleware;
+const { validateInitiatePayment, generatePaymentIntent } = paymentsMiddleware;
+
+const paymentsRoutes = express.Router();
+
+paymentsRoutes.post('/', validateInitiatePayment, checkUserToken, generatePaymentIntent);
+
+export default paymentsRoutes;

--- a/src/services/services.js
+++ b/src/services/services.js
@@ -115,6 +115,45 @@ const findAllOrders = async (model, contents, user) => {
   return data;
 };
 
+/**
+ * @description Gets all the orders of a specific user with their contents info
+ * @param {string} model Order model
+ * @param {string} contents Contents model
+ * @param {object} condition Object with condition eg. { id: 1 }
+ * @returns {array} data
+ */
+const findAllUserOrders = async (model, contents, condition) => {
+  const data = await model.findAll(
+    {
+      where: condition,
+      order: [
+        ['id', 'DESC'],
+      ],
+      include: [
+        { model: contents },
+      ],
+    },
+  );
+  return data;
+};
+
+/**
+ * @description Gets the menu categories and menu items
+ * @param {string} model Menu model
+ * @param {string} model Items model
+ * @returns {array} data
+ */
+const findMenuItems = async (model, items) => {
+  const data = await model.findAll(
+    {
+      include: [
+        { model: items },
+      ],
+    },
+  );
+  return data;
+};
+
 export default {
   saveData,
   findByCondition,
@@ -122,4 +161,6 @@ export default {
   saveManyRows,
   findOrderByConditionAll,
   findAllOrders,
+  findAllUserOrders,
+  findMenuItems,
 };

--- a/src/utils/messages.js
+++ b/src/utils/messages.js
@@ -51,6 +51,9 @@ const messages = {
   orderUpdateConflict: 'Update failed. Order status exists already',
   orderUpdateEmptyStatus: 'Status is required',
   orderUpdateInvalidStatus: 'Status must be one of [accepted, onthemove, completed]',
+  menuNotFound: 'Menu not found at the moment',
+  emptyAmount: 'Amount is required',
+  invalidAmount: 'Amount must be a positive number greater or equal to 1$',
 };
 
 export default messages;

--- a/src/validations/payments.js
+++ b/src/validations/payments.js
@@ -1,0 +1,29 @@
+import Joi from 'joi';
+import messages from '../utils/messages';
+import authentication from './authentication';
+
+const { createErrorMessages } = authentication;
+
+/**
+ * @description Validates the amount property of req.body
+ * @param {object} data
+ * @returns {object} Validation result object
+ */
+const initiatePayment = (data) => {
+  const schema = Joi.object({
+    amount: Joi.number().min(1).precision(2).required()
+      .messages(createErrorMessages(
+        'number',
+        `${messages.emptyAmount}`,
+        `${messages.invalidAmount}`,
+        `${messages.invalidAmount}`,
+        `${messages.invalidAmount}`,
+      )),
+  });
+  return schema.validate(data, {
+    abortEarly: false,
+    allowUnknown: false,
+  });
+};
+
+export default { initiatePayment };

--- a/tests/menu.test.js
+++ b/tests/menu.test.js
@@ -1,0 +1,89 @@
+import chai, { expect } from 'chai';
+import chaiHttp from 'chai-http';
+import server from '../src/server';
+import statusCodes from '../src/utils/statusCodes';
+import messages from '../src/utils/messages';
+import db from '../src/database/models';
+
+const {
+  success,
+  notFound,
+} = statusCodes;
+const {
+  loginSuccessful,
+  menuNotFound,
+} = messages;
+const baseUrl = '/api/menu';
+
+chai.use(chaiHttp);
+chai.should();
+
+let userToken = null;
+
+describe('CUSTOMER GET MENU', () => {
+  it('Valid login should return 200', (done) => {
+    chai
+      .request(server)
+      .post('/api/auth/login')
+      .send({
+        phoneNumber: process.env.TWILIO_CUSTOMER_NUMBER,
+        password: '@1helloworld',
+      })
+      .end((err, res) => {
+        if (err) done(err);
+        const { message, token } = res.body;
+        expect(res.status).to.equal(success);
+        expect(message);
+        expect(message).to.equal(loginSuccessful);
+        expect(token).to.be.a('string');
+        userToken = token;
+        done();
+      });
+  });
+  it('Menu found should return 200', (done) => {
+    chai
+      .request(server)
+      .get(baseUrl)
+      .set('Authorization', `Bearer ${userToken}`)
+      .end((err, res) => {
+        if (err) done(err);
+        const { data } = res.body;
+        expect(res.status).to.equal(success);
+        expect(data);
+        expect(data).to.be.a('array');
+        expect(data[0]).to.haveOwnProperty('id');
+        expect(data[0].id).to.be.a('number');
+        expect(data[0].id).to.equal(1);
+        expect(data[0]).to.haveOwnProperty('name');
+        expect(data[0].name).to.be.a('string');
+        expect(data[0]).to.haveOwnProperty('Items');
+        expect(data[0].Items).to.be.a('array');
+        expect(data[0].Items[0]).to.haveOwnProperty('id');
+        expect(data[0].Items[0]).to.haveOwnProperty('name');
+        expect(data[0].Items[0]).to.haveOwnProperty('description');
+        expect(data[0].Items[0]).to.haveOwnProperty('cost');
+        expect(data[0].Items[0]).to.haveOwnProperty('image');
+        expect(data[0].Items[0]).to.haveOwnProperty('menuId');
+        expect(data[0].Items[0].menuId).to.be.a('number');
+        done();
+      });
+  });
+  it('Clear items and menu records', async () => {
+    await db.sequelize.query('DELETE FROM "Items";');
+    await db.sequelize.query('DELETE FROM "Menus";');
+  });
+  it('Menu not found should return 404', (done) => {
+    chai
+      .request(server)
+      .get(baseUrl)
+      .set('Authorization', `Bearer ${userToken}`)
+      .end((err, res) => {
+        if (err) done(err);
+        const { error } = res.body;
+        expect(res.status).to.equal(notFound);
+        expect(error);
+        expect(error).to.equal(menuNotFound);
+        done();
+      });
+  });
+});

--- a/tests/orders.test.js
+++ b/tests/orders.test.js
@@ -88,6 +88,42 @@ describe('ADMIN GET EMPTY LIST OF ORDERS', () => {
   });
 });
 
+describe('USER GET EMPTY LIST OF ORDERS', () => {
+  it('Valid login should return 200', (done) => {
+    chai
+      .request(server)
+      .post('/api/auth/login')
+      .send({
+        phoneNumber: process.env.TWILIO_CUSTOMER_NUMBER,
+        password: '@1helloworld',
+      })
+      .end((err, res) => {
+        if (err) done(err);
+        const { message, token } = res.body;
+        expect(res.status).to.equal(success);
+        expect(message);
+        expect(message).to.equal(loginSuccessful);
+        expect(token).to.be.a('string');
+        userToken = token;
+        done();
+      });
+  });
+  it('Orders list not found should return 404', (done) => {
+    chai
+      .request(server)
+      .get(baseUrl)
+      .set('Authorization', `Bearer ${userToken}`)
+      .end((err, res) => {
+        if (err) done(err);
+        const { error } = res.body;
+        expect(res.status).to.equal(notFound);
+        expect(error);
+        expect(error).to.equal(ordersListNotFound);
+        done();
+      });
+  });
+});
+
 describe('CUSTOMER PLACE ORDER', () => {
   it('Valid login should return 200', (done) => {
     chai
@@ -381,6 +417,33 @@ describe('CUSTOMER GET ORDER', () => {
         done();
       });
   });
+  it('Orders found should return 200', (done) => {
+    chai
+      .request(server)
+      .get(baseUrl)
+      .set('Authorization', `Bearer ${userToken}`)
+      .end((err, res) => {
+        if (err) done(err);
+        const { data } = res.body;
+        expect(res.status).to.equal(success);
+        expect(data);
+        expect(data).to.be.a('array');
+        expect(data[0]).to.haveOwnProperty('id');
+        expect(data[0].id).to.be.a('number');
+        expect(data[0]).to.haveOwnProperty('total');
+        expect(data[0]).to.haveOwnProperty('status');
+        expect(data[0].status).to.equal('pending');
+        expect(data[0]).to.haveOwnProperty('paymentId');
+        expect(data[0]).to.haveOwnProperty('userId');
+        expect(data[0]).to.haveOwnProperty('Contents');
+        expect(data[0].Contents).to.be.a('array');
+        expect(data[0].Contents[0]).to.haveOwnProperty('itemId');
+        expect(data[0].Contents[0]).to.haveOwnProperty('itemName');
+        expect(data[0].Contents[0]).to.haveOwnProperty('cost');
+        expect(data[0].Contents[0]).to.haveOwnProperty('quantity');
+        done();
+      });
+  });
 });
 
 describe('ADMIN GET ORDER', () => {
@@ -487,7 +550,6 @@ describe('ADMIN GET LIST OF ORDERS', () => {
         expect(data).to.be.a('array');
         expect(data[0]).to.haveOwnProperty('id');
         expect(data[0].id).to.be.a('number');
-        expect(data[0].id).to.equal(2);
         expect(data[0]).to.haveOwnProperty('total');
         expect(data[0]).to.haveOwnProperty('status');
         expect(data[0].status).to.equal('pending');

--- a/tests/payments.test.js
+++ b/tests/payments.test.js
@@ -1,0 +1,92 @@
+import chai, { expect } from 'chai';
+import chaiHttp from 'chai-http';
+import server from '../src/server';
+import statusCodes from '../src/utils/statusCodes';
+import messages from '../src/utils/messages';
+
+const {
+  badRequest,
+  success,
+} = statusCodes;
+const {
+  loginSuccessful,
+  emptyAmount,
+} = messages;
+const baseUrl = '/api/payments';
+
+chai.use(chaiHttp);
+chai.should();
+
+let userToken = null;
+
+describe('GENERATE PAYMENT INTENT', () => {
+  it('Valid login should return 200', (done) => {
+    chai
+      .request(server)
+      .post('/api/auth/login')
+      .send({
+        phoneNumber: process.env.TWILIO_CUSTOMER_NUMBER,
+        password: '@1helloworld',
+      })
+      .end((err, res) => {
+        if (err) done(err);
+        const { message, token } = res.body;
+        expect(res.status).to.equal(success);
+        expect(message);
+        expect(message).to.equal(loginSuccessful);
+        expect(token).to.be.a('string');
+        userToken = token;
+        done();
+      });
+  });
+  it('Missing payment amount should return 400', (done) => {
+    chai
+      .request(server)
+      .post(baseUrl)
+      .set('Authorization', `Bearer ${userToken}`)
+      .end((err, res) => {
+        if (err) done(err);
+        const { error } = res.body;
+        expect(res.status).to.equal(badRequest);
+        expect(error);
+        expect(error).to.equal(emptyAmount);
+        done();
+      });
+  });
+  it('Invalid payment amount should return 400', (done) => {
+    chai
+      .request(server)
+      .post(baseUrl)
+      .set('Authorization', `Bearer ${userToken}`)
+      .send({
+        amount: 'hellothere',
+      })
+      .end((err, res) => {
+        if (err) done(err);
+        const { error } = res.body;
+        expect(res.status).to.equal(badRequest);
+        expect(error);
+        expect(error).to.equal('amount must be a number');
+        done();
+      });
+  });
+  it('Valid place order should return 201', (done) => {
+    chai
+      .request(server)
+      .post(baseUrl)
+      .set('Authorization', `Bearer ${userToken}`)
+      .send({
+        amount: 800,
+      })
+      .end((err, res) => {
+        if (err) done(err);
+        const { data } = res.body;
+        expect(res.status).to.equal(success);
+        expect(data);
+        expect(data).to.be.a('object');
+        expect(data).to.haveOwnProperty('publishableKey');
+        expect(data).to.haveOwnProperty('clientSecret');
+        done();
+      });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -940,6 +940,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.16.tgz#3cc351f8d48101deadfed4c9e4f116048d437b4b"
   integrity sha512-naXYePhweTi+BMv11TgioE2/FXU4fSl29HAH1ffxVciNsH3rYXjNP2yM8wqmSm7jS20gM8TIklKiTen+1iVncw==
 
+"@types/node@>=8.1.0":
+  version "14.14.34"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.34.tgz#07935194fc049069a1c56c0c274265abeddf88da"
+  integrity sha512-dBPaxocOK6UVyvhbnpFIj2W+S+1cBTkHQbFQfeeJhoKFbzYcVUGHvddeWPSucKATb3F0+pgDq0i6ghEaZjsugA==
+
 "@types/superagent@^3.8.3":
   version "3.8.7"
   resolved "https://registry.yarnpkg.com/@types/superagent/-/superagent-3.8.7.tgz#1f1ed44634d5459b3a672eb7235a8e7cfd97704c"
@@ -4251,6 +4256,11 @@ qs@^6.5.1, qs@^6.9.4:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.4.tgz#9090b290d1f91728d3c22e54843ca44aea5ab687"
   integrity sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ==
 
+qs@^6.6.0:
+  version "6.9.6"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.6.tgz#26ed3c8243a431b2924aca84cc90471f35d5a0ee"
+  integrity sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ==
+
 qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
@@ -4910,6 +4920,14 @@ strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
+
+stripe@^8.138.0:
+  version "8.138.0"
+  resolved "https://registry.yarnpkg.com/stripe/-/stripe-8.138.0.tgz#032ad239cda2058ab0cc391874b4d40e449cafdb"
+  integrity sha512-Cr+jzcacXOlL1Wrd7xxcE9nk9OBF0l73Z/oCAlBHXldtRr2FRflg/2h4g4Na3LTlcLRYtx+jnKs64/WPOqmpsA==
+  dependencies:
+    "@types/node" ">=8.1.0"
+    qs "^6.6.0"
 
 superagent@^3.7.0:
   version "3.8.3"


### PR DESCRIPTION
#### What does this PR do?

- Adds a script to create the menu categories and their items
- Adds `/api/menu` endpoint to fetch menu categories and their items
- Adds `/api/payments` endpoint to create a stripe payment intent
- Adds `/api/orders` endpoint to fetch the list of orders
- Updates the README file

#### Description of Task to be completed?

- [x] Refactor and add more tests
- [x] Create a script to create the menu categories and their items
- [x] Implement endpoint to fetch the menu categories and their items
- [x] Implement endpoint to initiate payment by creating a stripe payment intent
- [x] Implement endpoint for a user to fetch own list of orders
